### PR TITLE
jump command changes

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/Commands.java
+++ b/src/main/java/dev/dfonline/codeclient/Commands.java
@@ -1,8 +1,6 @@
 package dev.dfonline.codeclient;
 
-import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;


### PR DESCRIPTION
i don't really expect this to be accepted, but i made a few changes to the `/jump` command to make it a little nicer to use.
- added an alias: `/goto`
- removed case-sensitivity on jumping to both event types, but kept it for processes and functions (since they are case-sensitive).
- added a partial search if there are no exact matches, e.g. `/goto player heal` will send you to the `PlayerHeal` event.