### PR TITLE
code search command

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/Commands.java
+++ b/src/main/java/dev/dfonline/codeclient/Commands.java
@@ -395,7 +395,7 @@ public class Commands {
                             var action = Text.empty().append(" [⏼]").setStyle(Style.EMPTY
                                     .withColor(Formatting.GREEN)
                                     .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/jump %s %s", sub, name)))
-                                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.translatable("codeclient.search.hover.teleport", String.format("x: %s, y: %s, z: %s", pos.getX(), pos.getY(), pos.getZ()))))
+                                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.translatable("codeclient.search.hover.teleport", pos.getX(), pos.getY(), pos.getZ())))
                             );
                             var entry = Text.empty().append("\n • ").formatted(Formatting.GREEN)
                                     .append(Text.empty().append(name).formatted(Formatting.WHITE))

--- a/src/main/java/dev/dfonline/codeclient/Commands.java
+++ b/src/main/java/dev/dfonline/codeclient/Commands.java
@@ -369,6 +369,48 @@ public class Commands {
             return -1;
         })));
 
+        dispatcher.register(literal("search")
+                .then(argument("query",greedyString()).suggests((context,builder) -> suggestJump(JumpType.ANY, context, builder)).executes(context -> {
+                    if(CodeClient.location instanceof Dev dev) {
+                        var query = context.getArgument("query", String.class);
+                        var results = dev.scanForSigns(JumpType.ANY.pattern,Pattern.compile("^.*"+Pattern.quote(query)+".*$", Pattern.CASE_INSENSITIVE));
+
+                        if (results == null || results.isEmpty()) {
+                            Utility.sendMessage(Text.literal("No results."), ChatType.INFO);
+                            return 0;
+                        }
+
+                        var message = Text.empty().append("Search Results:");
+                        results.forEach((pos,text) -> {
+                            var type = text.getMessage(0, false).getString();
+                            var name = text.getMessage(1, false).getString();
+
+                            String sub = null;
+                            if (JumpType.PLAYER_EVENT.pattern.matcher(type).matches()) sub = "player";
+                            else if (JumpType.ENTITY_EVENT.pattern.matcher(type).matches()) sub = "entity";
+                            else if (JumpType.FUNCTION.pattern.matcher(type).matches()) sub = "func";
+                            else if (JumpType.PROCESS.pattern.matcher(type).matches()) sub = "proc";
+                            else return;
+
+                            var action = Text.empty().append(" [⏼]").setStyle(Style.EMPTY
+                                    .withColor(Formatting.GREEN)
+                                    .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/jump "+sub+" "+name))
+                                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.of("Click to Teleport\nx: "+pos.getX()+", y: "+pos.getY()+", z: "+pos.getZ())))
+                            );
+                            var entry = Text.empty().append("\n • ").formatted(Formatting.GREEN)
+                                    .append(Text.empty().append(name).formatted(Formatting.WHITE))
+                                    .append(action);
+                            message.append(entry);
+                        });
+
+                        Utility.sendMessage(message, ChatType.SUCCESS);
+                    } else {
+                        Utility.sendMessage(Text.of("Could not execute search."), ChatType.FAIL);
+                    }
+                    return 0;
+                })
+        ));
+
         LiteralCommandNode<FabricClientCommandSource> jumpCommand = dispatcher.register(literal("jump")
                 .then(literal("player").then(argument("name", greedyString()).suggests((context, builder) -> suggestJump(JumpType.PLAYER_EVENT, context, builder)).executes(context -> {
                     var name = context.getArgument("name", String.class);
@@ -613,7 +655,8 @@ public class Commands {
         PLAYER_EVENT("PLAYER EVENT"),
         ENTITY_EVENT("ENTITY EVENT"),
         FUNCTION("FUNCTION"),
-        PROCESS("PROCESS");
+        PROCESS("PROCESS"),
+        ANY("(((PLAYER)|(ENTITY)) EVENT)|(FUNCTION)|(PROCESS)");
 
         public final Pattern pattern;
         JumpType(String scan) {

--- a/src/main/java/dev/dfonline/codeclient/Commands.java
+++ b/src/main/java/dev/dfonline/codeclient/Commands.java
@@ -376,11 +376,11 @@ public class Commands {
                         var results = dev.scanForSigns(JumpType.ANY.pattern,Pattern.compile("^.*"+Pattern.quote(query)+".*$", Pattern.CASE_INSENSITIVE));
 
                         if (results == null || results.isEmpty()) {
-                            Utility.sendMessage(Text.literal("No results."), ChatType.INFO);
+                            Utility.sendMessage(Text.translatable("codeclient.search.no_results"), ChatType.INFO);
                             return 0;
                         }
 
-                        var message = Text.empty().append("Search Results:");
+                        var message = Text.translatable("codeclient.search.results");
                         results.forEach((pos,text) -> {
                             var type = text.getMessage(0, false).getString();
                             var name = text.getMessage(1, false).getString();
@@ -395,7 +395,7 @@ public class Commands {
                             var action = Text.empty().append(" [⏼]").setStyle(Style.EMPTY
                                     .withColor(Formatting.GREEN)
                                     .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/jump %s %s", sub, name)))
-                                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.of("Click to Teleport\nx: "+pos.getX()+", y: "+pos.getY()+", z: "+pos.getZ())))
+                                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.translatable("codeclient.search.hover.teleport", String.format("x: %s, y: %s, z: %s", pos.getX(), pos.getY(), pos.getZ()))))
                             );
                             var entry = Text.empty().append("\n • ").formatted(Formatting.GREEN)
                                     .append(Text.empty().append(name).formatted(Formatting.WHITE))
@@ -405,7 +405,7 @@ public class Commands {
 
                         Utility.sendMessage(message, ChatType.SUCCESS);
                     } else {
-                        Utility.sendMessage(Text.of("Could not execute search."), ChatType.FAIL);
+                        Utility.sendMessage(Text.translatable("codeclient.warning.dev_mode"), ChatType.FAIL);
                     }
                     return 0;
                 })

--- a/src/main/java/dev/dfonline/codeclient/Commands.java
+++ b/src/main/java/dev/dfonline/codeclient/Commands.java
@@ -394,7 +394,7 @@ public class Commands {
 
                             var action = Text.empty().append(" [⏼]").setStyle(Style.EMPTY
                                     .withColor(Formatting.GREEN)
-                                    .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/jump "+sub+" "+name))
+                                    .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/jump %s %s", sub, name)))
                                     .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.of("Click to Teleport\nx: "+pos.getX()+", y: "+pos.getY()+", z: "+pos.getZ())))
                             );
                             var entry = Text.empty().append("\n • ").formatted(Formatting.GREEN)

--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -69,7 +69,7 @@
 
   "codeclient.search.results": "Search Results:",
   "codeclient.search.no_results": "No results.",
-  "codeclient.search.hover.teleport": "Click to teleport\n%s",
+  "codeclient.search.hover.teleport": "Click to teleport\nx: %s, y: %s, z: %s",
 
   "codeclient.files.template_fail": "Couldn't load templates.",
   "codeclient.files.hold_template": "You need to hold a template to save.",

--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -67,6 +67,10 @@
   "codeclient.warning.dev_mode": "You must be in dev mode!",
   "codeclient.warning.creative_mode": "You must be in creative mode!",
 
+  "codeclient.search.results": "Search Results:",
+  "codeclient.search.no_results": "No results.",
+  "codeclient.search.hover.teleport": "Click to teleport\n%s",
+
   "codeclient.files.template_fail": "Couldn't load templates.",
   "codeclient.files.hold_template": "You need to hold a template to save.",
   "codeclient.files.empty_dir": "Please use an empty folder to save into.",


### PR DESCRIPTION
adds a /search command that searches all code starter blocks for the given search query and provides a list with a clickable action to teleport to the codeline.

> example usage running `/search init` on a plot.
> 
> ![image](https://github.com/DFOnline/CodeClient/assets/66442608/aac590de-baa0-4060-a41d-526d027717ad)
