### PR TITLE
fix indeterminate plot size issue on mega plots

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/CodeClient.java
+++ b/src/main/java/dev/dfonline/codeclient/CodeClient.java
@@ -152,7 +152,7 @@ public class CodeClient implements ModInitializer {
                 if(MEGA_ONE.isOf(Blocks.GRASS_BLOCK) && MEGA.isOf(Blocks.GRASS_BLOCK)) {
                     dev.setSize(Plot.Size.MEGA);
                 }
-                else if (MEGA.isOf(Blocks.GRASS_BLOCK) && !MEGA_ONE.isOf(Blocks.VOID_AIR)) {
+                else if (!MEGA.isOf(Blocks.STONE) && !MEGA_ONE.isOf(Blocks.VOID_AIR)) {
                     dev.setSize(Plot.Size.MEGA);
                 }
                 else if (!(FIFTY.isOf(Blocks.VOID_AIR) || FIFTY_ONE.isOf(Blocks.VOID_AIR)) && (!FIFTY.isOf(FIFTY_ONE.getBlock())))


### PR DESCRIPTION
mega plots with underground code space were not be given a plot size. this pr should solve the issue by changing a check to look for any _not stone block_ instead of only a grass block.