### PR TITLE
action viewer overlay

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/config/Config.java
+++ b/src/main/java/dev/dfonline/codeclient/config/Config.java
@@ -68,9 +68,9 @@ public class Config {
     public boolean ChatEditsVars = true;
     public boolean InsertOverlay = true;
     public boolean ParameterGhosts = true;
-    public boolean ActionViewer = false;
+    public boolean ActionViewer = true;
     public boolean InvertActionViewerScroll = false;
-    public ActionViewerAlignment ActionViewerLocation = ActionViewerAlignment.CENTER;
+    public ActionViewerAlignment ActionViewerLocation = ActionViewerAlignment.TOP;
 
     public Config() {
     }
@@ -581,7 +581,7 @@ public class Config {
                                         .name(Text.translatable("codeclient.config.action_viewer"))
                                         .description(OptionDescription.of(Text.translatable("codeclient.config.action_viewer.description")))
                                         .binding(
-                                                false,
+                                                true,
                                                 () -> ActionViewer,
                                                 opt -> ActionViewer = opt
                                         )
@@ -601,7 +601,7 @@ public class Config {
                                         .name(Text.translatable("codeclient.config.action_viewer_alignment"))
                                         .description(OptionDescription.of(Text.translatable("codeclient.config.category.action_viewer.description")))
                                         .binding(
-                                                ActionViewerAlignment.CENTER,
+                                                ActionViewerAlignment.TOP,
                                                 () -> ActionViewerLocation,
                                                 opt -> ActionViewerLocation = opt
                                         )

--- a/src/main/java/dev/dfonline/codeclient/config/Config.java
+++ b/src/main/java/dev/dfonline/codeclient/config/Config.java
@@ -69,6 +69,8 @@ public class Config {
     public boolean InsertOverlay = true;
     public boolean ParameterGhosts = true;
     public boolean ActionViewer = false;
+    public boolean InvertActionViewerScroll = false;
+    public ActionViewerAlignment ActionViewerLocation = ActionViewerAlignment.CENTER;
 
     public Config() {
     }
@@ -141,6 +143,8 @@ public class Config {
             object.addProperty("InsertOverlay",InsertOverlay);
             object.addProperty("ParameterGhosts",ParameterGhosts);
             object.addProperty("ActionViewer",ActionViewer);
+            object.addProperty("InvertActionViewerScroll",InvertActionViewerScroll);
+            object.addProperty("ActionViewerLocation",ActionViewerLocation.name());
             FileManager.writeConfig(object.toString());
         } catch (Exception e) {
             CodeClient.LOGGER.info("Couldn't save config: " + e);
@@ -568,15 +572,41 @@ public class Config {
                                 )
                                 .controller(TickBoxControllerBuilder::create)
                                 .build())
-                        .option(Option.createBuilder(Boolean.class)
-                                .name(Text.translatable("codeclient.config.action_viewer"))
-                                .description(OptionDescription.of(Text.translatable("codeclient.config.action_viewer.description")))
-                                .binding(
-                                        false,
-                                        () -> ActionViewer,
-                                        opt -> ActionViewer = opt
-                                )
-                                .controller(TickBoxControllerBuilder::create)
+                        //</editor-fold>
+                        //<editor-fold desc="Action Viewer">
+                        .group(OptionGroup.createBuilder()
+                                .name(Text.literal("Action Viewer"))
+                                .description(OptionDescription.of(Text.literal("Display a tooltip displaying the code blocks description.")))
+                                .option(Option.createBuilder(Boolean.class)
+                                        .name(Text.translatable("codeclient.config.action_viewer"))
+                                        .description(OptionDescription.of(Text.translatable("codeclient.config.action_viewer.description")))
+                                        .binding(
+                                                false,
+                                                () -> ActionViewer,
+                                                opt -> ActionViewer = opt
+                                        )
+                                        .controller(TickBoxControllerBuilder::create)
+                                        .build())
+                                .option(Option.createBuilder(Boolean.class)
+                                        .name(Text.translatable("codeclient.config.invert_action_viewer_scroll"))
+                                        .description(OptionDescription.of(Text.translatable("codeclient.config.invert_action_viewer_scroll.description")))
+                                        .binding(
+                                                false,
+                                                () -> InvertActionViewerScroll,
+                                                opt -> InvertActionViewerScroll = opt
+                                        )
+                                        .controller(TickBoxControllerBuilder::create)
+                                        .build())
+                                .option(Option.createBuilder(ActionViewerAlignment.class)
+                                        .name(Text.translatable("codeclient.config.action_viewer_alignment"))
+                                        .description(OptionDescription.of(Text.translatable("codeclient.config.action_viewer_alignment.description")))
+                                        .binding(
+                                                ActionViewerAlignment.CENTER,
+                                                () -> ActionViewerLocation,
+                                                opt -> ActionViewerLocation = opt
+                                        )
+                                        .controller(nodeOption -> () -> new EnumController<>(nodeOption, ActionViewerAlignment.class))
+                                        .build())
                                 .build())
                         //</editor-fold>
                         //<editor-fold desc="Chest Preview">
@@ -781,6 +811,17 @@ public class Config {
         CustomChestMenuType(String description, CustomChestNumbers size) {
             this.description = description;
             this.size = size;
+        }
+    }
+
+    public enum ActionViewerAlignment {
+        CENTER("Pins the tooltip to the center of the code chest."),
+        TOP("Pins the tooltip to the top of the code chest.");
+
+        public final String description;
+
+        ActionViewerAlignment(String description) {
+            this.description = description;
         }
     }
 }

--- a/src/main/java/dev/dfonline/codeclient/config/Config.java
+++ b/src/main/java/dev/dfonline/codeclient/config/Config.java
@@ -68,6 +68,7 @@ public class Config {
     public boolean ChatEditsVars = true;
     public boolean InsertOverlay = true;
     public boolean ParameterGhosts = true;
+    public boolean ActionViewer = false;
 
     public Config() {
     }
@@ -139,6 +140,7 @@ public class Config {
             object.addProperty("ChatEditsVars",ChatEditsVars);
             object.addProperty("InsertOverlay",InsertOverlay);
             object.addProperty("ParameterGhosts",ParameterGhosts);
+            object.addProperty("ActionViewer",ActionViewer);
             FileManager.writeConfig(object.toString());
         } catch (Exception e) {
             CodeClient.LOGGER.info("Couldn't save config: " + e);
@@ -563,6 +565,16 @@ public class Config {
                                         true,
                                         () -> ParameterGhosts,
                                         opt -> ParameterGhosts = opt
+                                )
+                                .controller(TickBoxControllerBuilder::create)
+                                .build())
+                        .option(Option.createBuilder(Boolean.class)
+                                .name(Text.translatable("codeclient.config.action_viewer"))
+                                .description(OptionDescription.of(Text.translatable("codeclient.config.action_viewer.description")))
+                                .binding(
+                                        false,
+                                        () -> ActionViewer,
+                                        opt -> ActionViewer = opt
                                 )
                                 .controller(TickBoxControllerBuilder::create)
                                 .build())

--- a/src/main/java/dev/dfonline/codeclient/config/Config.java
+++ b/src/main/java/dev/dfonline/codeclient/config/Config.java
@@ -575,8 +575,8 @@ public class Config {
                         //</editor-fold>
                         //<editor-fold desc="Action Viewer">
                         .group(OptionGroup.createBuilder()
-                                .name(Text.literal("Action Viewer"))
-                                .description(OptionDescription.of(Text.literal("Display a tooltip displaying the code blocks description.")))
+                                .name(Text.translatable("codeclient.config.category.action_viewer"))
+                                .description(OptionDescription.of(Text.translatable("codeclient.config.category.action_viewer.description")))
                                 .option(Option.createBuilder(Boolean.class)
                                         .name(Text.translatable("codeclient.config.action_viewer"))
                                         .description(OptionDescription.of(Text.translatable("codeclient.config.action_viewer.description")))
@@ -599,7 +599,7 @@ public class Config {
                                         .build())
                                 .option(Option.createBuilder(ActionViewerAlignment.class)
                                         .name(Text.translatable("codeclient.config.action_viewer_alignment"))
-                                        .description(OptionDescription.of(Text.translatable("codeclient.config.action_viewer_alignment.description")))
+                                        .description(OptionDescription.of(Text.translatable("codeclient.config.category.action_viewer.description")))
                                         .binding(
                                                 ActionViewerAlignment.CENTER,
                                                 () -> ActionViewerLocation,
@@ -815,13 +815,7 @@ public class Config {
     }
 
     public enum ActionViewerAlignment {
-        CENTER("Pins the tooltip to the center of the code chest."),
-        TOP("Pins the tooltip to the top of the code chest.");
-
-        public final String description;
-
-        ActionViewerAlignment(String description) {
-            this.description = description;
-        }
+        CENTER,
+        TOP;
     }
 }

--- a/src/main/java/dev/dfonline/codeclient/config/Config.java
+++ b/src/main/java/dev/dfonline/codeclient/config/Config.java
@@ -599,7 +599,7 @@ public class Config {
                                         .build())
                                 .option(Option.createBuilder(ActionViewerAlignment.class)
                                         .name(Text.translatable("codeclient.config.action_viewer_alignment"))
-                                        .description(OptionDescription.of(Text.translatable("codeclient.config.category.action_viewer.description")))
+                                        .description(OptionDescription.of(Text.translatable("codeclient.config.action_viewer_alignment.description")))
                                         .binding(
                                                 ActionViewerAlignment.TOP,
                                                 () -> ActionViewerLocation,

--- a/src/main/java/dev/dfonline/codeclient/dev/InteractionManager.java
+++ b/src/main/java/dev/dfonline/codeclient/dev/InteractionManager.java
@@ -7,6 +7,7 @@ import dev.dfonline.codeclient.ChatType;
 import dev.dfonline.codeclient.CodeClient;
 import dev.dfonline.codeclient.Utility;
 import dev.dfonline.codeclient.config.Config;
+import dev.dfonline.codeclient.dev.overlay.ActionViewer;
 import dev.dfonline.codeclient.dev.overlay.ChestPeeker;
 import dev.dfonline.codeclient.location.Dev;
 import dev.dfonline.codeclient.switcher.ScopeSwitcher;
@@ -241,6 +242,7 @@ public class InteractionManager {
 
     public static BlockHitResult onBlockInteract(BlockHitResult hitResult) {
         SlotGhostManager.onClickChest(hitResult);
+        ActionViewer.onClickChest(hitResult);
         if (CodeClient.location instanceof Dev plot && plot.isInDev(hitResult.getBlockPos())) {
             plot.getLineStartCache();
             ChestPeeker.invalidate();

--- a/src/main/java/dev/dfonline/codeclient/dev/overlay/ActionViewer.java
+++ b/src/main/java/dev/dfonline/codeclient/dev/overlay/ActionViewer.java
@@ -143,7 +143,7 @@ public class ActionViewer {
             vector.add(6, -difference); // align to chest
 
             int space = ((screenWidth - backgroundWidth) / 2) - 6 /* for padding */;
-            if (width > space + 4) {
+            if (width + 6 > space) {
                 if (isMouseInside(x+6, y-difference, width, height, screenWidth, screenHeight)) {
                     vector.add(space-width - 5, 0);
                 }

--- a/src/main/java/dev/dfonline/codeclient/dev/overlay/ActionViewer.java
+++ b/src/main/java/dev/dfonline/codeclient/dev/overlay/ActionViewer.java
@@ -61,29 +61,6 @@ public class ActionViewer {
         }
     }
 
-    public static ItemStack getReferenceBook() {
-        var player = CodeClient.MC.player;
-        if (player == null) return null;
-        var inventory = player.getInventory();
-
-        ItemStack referenceBook = null;
-        for (int index = 0; index < inventory.size(); index++) {
-            var itemStack = inventory.getStack(index);
-            if (itemStack.isEmpty()) continue;
-            if (itemStack.getItem() instanceof WrittenBookItem item) {
-                NbtCompound nbt = itemStack.getNbt();
-                if (nbt == null) continue;
-                var data = nbt.getCompound("PublicBukkitValues");
-                var instance = data.getString("hypercube:item_instance");
-                if (instance == null) continue;
-                referenceBook = itemStack;
-                break;
-            }
-        }
-        if (referenceBook == null || referenceBook.getName().getString().contains("◆ Reference Book ◆")) return null;
-        return referenceBook;
-    }
-
     public static List<Text> getOverlayText() {
         if (CodeClient.location instanceof Dev dev) {
             if (!Config.getConfig().ActionViewer) return null;
@@ -91,15 +68,11 @@ public class ActionViewer {
             if (action == null) {
                 if (!reference) return null;
                 if (book == null) {
-                    item = getReferenceBook();
-                    if (item == null) return null;
-                    var displayBook = item.copy();
-                    var name = displayBook.getName().copy().withColor(0xFFFFFF);
-                    displayBook.setCustomName(name); // continuity with actions
-                    book = displayBook;
-                } else {
-                    item = book;
+                    var rb = dev.getReferenceBook();
+                    if (rb.isEmpty()) return null;
+                    book = rb.getItem();
                 }
+                item = book;
             } else {
                 item = action.icon.getItem();
             }

--- a/src/main/java/dev/dfonline/codeclient/dev/overlay/ActionViewer.java
+++ b/src/main/java/dev/dfonline/codeclient/dev/overlay/ActionViewer.java
@@ -1,0 +1,133 @@
+package dev.dfonline.codeclient.dev.overlay;
+
+import com.google.common.collect.Lists;
+import dev.dfonline.codeclient.CodeClient;
+import dev.dfonline.codeclient.config.Config;
+import dev.dfonline.codeclient.dev.menu.customchest.CustomChestMenu;
+import dev.dfonline.codeclient.hypercube.actiondump.Action;
+import dev.dfonline.codeclient.hypercube.actiondump.ActionDump;
+import dev.dfonline.codeclient.location.Dev;
+import net.minecraft.block.entity.ChestBlockEntity;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.tooltip.TooltipBackgroundRenderer;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.gui.tooltip.TooltipPositioner;
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.text.Text;
+import net.minecraft.util.hit.BlockHitResult;
+import org.joml.Vector2i;
+import org.joml.Vector2ic;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class ActionViewer {
+    private static Action action;
+
+    public static void invalidate() {
+        action = null;
+    }
+    public static void onClickChest(BlockHitResult hitResult) {
+        invalidate();
+        var world = CodeClient.MC.world;
+        if (world == null || !Config.getConfig().ActionViewer) return;
+        var position = hitResult.getBlockPos();
+        if (CodeClient.location instanceof Dev dev && dev.isInDev(position) && world.getBlockEntity(position) instanceof ChestBlockEntity) {
+            var signEntity = world.getBlockEntity(position.down().west());
+            if (signEntity instanceof SignBlockEntity sign) {
+                try {
+                    action = ActionDump.getActionDump().findAction(sign.getFrontText());
+                } catch (Exception ignored) {
+
+                }
+            }
+        }
+    }
+
+    public static List<Text> getOverlayText() {
+        if (CodeClient.location instanceof Dev dev) {
+            if (!Config.getConfig().ActionViewer || action == null) return null;
+            var item = action.icon.getItem();
+            return item.getTooltip(null, TooltipContext.BASIC);
+        }
+        return null;
+    }
+
+    public static void render(DrawContext context, HandledScreen<?> handledScreen) {
+        if (!(handledScreen instanceof GenericContainerScreen || handledScreen instanceof CustomChestMenu))
+            return;
+        var text = getOverlayText();
+        if (text == null) return;
+
+        drawTooltip(context, handledScreen, transformText(text), 176, 0, 300);
+    }
+
+    private static List<TooltipComponent> transformText(List<Text> texts) {
+        var orderedText = Lists.transform(texts, Text::asOrderedText);
+        return  orderedText.stream().map(TooltipComponent::of).toList();
+    }
+
+    // this implementation of draw tooltip allows a change in the z-index of the rendered tooltip.
+    private static void drawTooltip(DrawContext context, HandledScreen<?> handledScreen, List<TooltipComponent> components, int x, int y, int z) {
+        var textRenderer = CodeClient.MC.textRenderer;
+
+        var positioner = ActionTooltipPositioner.INSTANCE;
+        if (handledScreen instanceof CustomChestMenu menu) {
+            var handler = menu.getScreenHandler();
+            positioner.setBackgroundHeight(handler.numbers.MENU_HEIGHT);
+            x += handler.numbers.MENU_WIDTH - 176;
+        } else {
+            positioner.setBackgroundHeight(166);
+        }
+
+        if (components.isEmpty()) return;
+        int tooltipWidth = 0;
+        int tooltipHeight = components.size() == 1 ? -2 : 0;
+
+        TooltipComponent tooltipComponent;
+        for (Iterator<TooltipComponent> iterator = components.iterator(); iterator.hasNext(); tooltipHeight += tooltipComponent.getHeight()) {
+            tooltipComponent = iterator.next();
+            int width = tooltipComponent.getWidth(textRenderer);
+            if (width > tooltipWidth) {
+                tooltipWidth = width;
+            }
+        }
+        Vector2ic vector = positioner.getPosition(context.getScaledWindowWidth(), context.getScaledWindowHeight(), x, y, tooltipWidth, tooltipHeight);
+        context.getMatrices().push();
+
+        var finalWidth = tooltipWidth;
+        var finalHeight = tooltipHeight;
+        context.draw(() -> TooltipBackgroundRenderer.render(context, vector.x(), vector.y(), finalWidth, finalHeight, z));
+        context.getMatrices().translate(0.0F, 0.0F, (float) z);
+
+        int textY = vector.y();
+        for (int index = 0; index < components.size(); ++index) {
+            tooltipComponent = components.get(index);
+            tooltipComponent.drawText(textRenderer, vector.x(), textY, context.getMatrices().peek().getPositionMatrix(), context.getVertexConsumers());
+            textY += tooltipComponent.getHeight() + (index == 0 ? 2 : 0);
+        }
+
+        context.getMatrices().pop();
+    }
+
+    private static class ActionTooltipPositioner implements TooltipPositioner {
+        public static final ActionTooltipPositioner INSTANCE = new ActionTooltipPositioner();
+        private int backgroundHeight = 166;
+
+        private ActionTooltipPositioner() {
+        }
+
+        public Vector2ic getPosition(int screenWidth, int screenHeight, int x, int y, int width, int height) {
+            int difference = (height - backgroundHeight) / 2;
+            return (new Vector2i(x, y)).add(6, -difference);
+        }
+
+        public void setBackgroundHeight(int backgroundHeight) {
+            this.backgroundHeight = backgroundHeight;
+        }
+    }
+}

--- a/src/main/java/dev/dfonline/codeclient/hypercube/ReferenceBook.java
+++ b/src/main/java/dev/dfonline/codeclient/hypercube/ReferenceBook.java
@@ -1,0 +1,40 @@
+package dev.dfonline.codeclient.hypercube;
+
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.WrittenBookItem;
+import net.minecraft.text.Text;
+
+import java.util.List;
+
+public class ReferenceBook {
+    final ItemStack book;
+
+    public ReferenceBook(ItemStack item) throws IllegalArgumentException {
+        if (!validate(item)) throw new IllegalArgumentException("Given item is not a ReferenceBook!");
+        this.book = item.copy();
+    }
+
+    private boolean validate(ItemStack item) {
+        if (item.getItem() instanceof WrittenBookItem) {
+            var nbt = item.getSubNbt("PublicBukkitValues");
+            return nbt != null && !nbt.getString("hypercube:item_instance").isEmpty();
+        }
+        return false;
+    }
+
+    public boolean isEmpty() {
+        return book.isEmpty() || book.getName().getString().contains("◆ Reference Book ◆");
+    }
+
+    public ItemStack getItem() {
+        return book;
+    }
+
+    public List<Text> getTooltip() {
+        return book.getTooltip(null, TooltipContext.BASIC);
+    }
+
+    // todo: parse into action?
+
+}

--- a/src/main/java/dev/dfonline/codeclient/location/Dev.java
+++ b/src/main/java/dev/dfonline/codeclient/location/Dev.java
@@ -1,5 +1,8 @@
 package dev.dfonline.codeclient.location;
 
+import dev.dfonline.codeclient.CodeClient;
+import dev.dfonline.codeclient.hypercube.ReferenceBook;
+
 public class Dev extends Creator {
     public Dev(double x, double z) {
         this.hasDev = true;
@@ -8,6 +11,22 @@ public class Dev extends Creator {
 
     public void setDevSpawn(double x, double z) {
         setOrigin((int) (x + 10.5), (int) (z - 10.5));
+    }
+
+    public ReferenceBook getReferenceBook() {
+        var player = CodeClient.MC.player;
+        if (player == null) return null;
+        var inventory = player.getInventory();
+
+        for (int index = 0; index < inventory.size(); index++) {
+            var itemStack = inventory.getStack(index);
+            try {
+                return new ReferenceBook(itemStack);
+            } catch (IllegalArgumentException ignored) {
+
+            }
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/dev/dfonline/codeclient/mixin/MMouse.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/MMouse.java
@@ -1,6 +1,7 @@
 package dev.dfonline.codeclient.mixin;
 
 import dev.dfonline.codeclient.dev.BuildPhaser;
+import dev.dfonline.codeclient.dev.overlay.ActionViewer;
 import net.minecraft.client.Mouse;
 import net.minecraft.client.network.ClientPlayerEntity;
 import dev.dfonline.codeclient.dev.InsertOverlay;
@@ -13,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class MMouse {
     @Redirect(method = "onMouseScroll", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;mouseScrolled(DDDD)Z"))
     private boolean mouseScrolled(Screen instance, double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-        return InsertOverlay.mouseScrolled(mouseX,mouseY,horizontalAmount,verticalAmount) || instance.mouseScrolled(mouseX,mouseY,horizontalAmount,verticalAmount);
+        return InsertOverlay.mouseScrolled(mouseX,mouseY,horizontalAmount,verticalAmount) || ActionViewer.scroll(instance,mouseX,mouseY,horizontalAmount,verticalAmount) || instance.mouseScrolled(mouseX,mouseY,horizontalAmount,verticalAmount);
     }
 
     @Redirect(method = "onMouseScroll", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isSpectator()Z"))

--- a/src/main/java/dev/dfonline/codeclient/mixin/screen/MHandledScreen.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/screen/MHandledScreen.java
@@ -38,7 +38,7 @@ public abstract class MHandledScreen {
     private void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         SlotGhostManager.render(delta);
         InsertOverlay.render(context,mouseX,mouseY,(HandledScreen<?>) (Object) this, this.x, this.y);
-        ActionViewer.render(context,(HandledScreen<?>) (Object) this);
+        ActionViewer.render(context, mouseX, mouseY,(HandledScreen<?>) (Object) this);
     }
 
     @Redirect(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/slot/Slot;hasStack()Z"))

--- a/src/main/java/dev/dfonline/codeclient/mixin/screen/MHandledScreen.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/screen/MHandledScreen.java
@@ -3,7 +3,10 @@ package dev.dfonline.codeclient.mixin.screen;
 import dev.dfonline.codeclient.dev.InsertOverlay;
 import dev.dfonline.codeclient.dev.InteractionManager;
 import dev.dfonline.codeclient.dev.SlotGhostManager;
+import dev.dfonline.codeclient.dev.overlay.ActionViewer;
+import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.ScreenHandler;
@@ -35,6 +38,7 @@ public abstract class MHandledScreen {
     private void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         SlotGhostManager.render(delta);
         InsertOverlay.render(context,mouseX,mouseY,(HandledScreen<?>) (Object) this, this.x, this.y);
+        ActionViewer.render(context,(HandledScreen<?>) (Object) this);
     }
 
     @Redirect(method = "drawMouseoverTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/slot/Slot;hasStack()Z"))

--- a/src/main/java/dev/dfonline/codeclient/mixin/screen/MHandledScreens.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/screen/MHandledScreens.java
@@ -5,6 +5,7 @@ import dev.dfonline.codeclient.dev.InsertOverlay;
 import dev.dfonline.codeclient.dev.InteractionManager;
 import dev.dfonline.codeclient.dev.menu.customchest.CustomChestHandler;
 import dev.dfonline.codeclient.dev.menu.customchest.CustomChestMenu;
+import dev.dfonline.codeclient.dev.overlay.ActionViewer;
 import net.minecraft.client.gui.screen.ingame.HandledScreens;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
@@ -34,6 +35,8 @@ public class MHandledScreens {
                 //noinspection rawtypes
                 return (Provider) (handler, playerInventory, title) -> new CustomChestMenu(new CustomChestHandler(handler.syncId), playerInventory, title);
             }
+        } else if (Config.getConfig().ActionViewer) {
+            ActionViewer.invalidate();
         }
         return PROVIDERS.get(type);
     }

--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -18,13 +18,15 @@
   "codeclient.config.insert_overlay.description": "Click on an empty slot in a code chest to insert a value.",
   "codeclient.config.param_ghosts": "Parameter Ghosts",
   "codeclient.config.param_ghosts.description": "See and be able to hover parameter information in chest slots.",
+
+  "codeclient.config.category.action_viewer": "Action Viewer",
+  "codeclient.config.category.action_viewer.description": "Display a tooltip displaying the code blocks description.",
   "codeclient.config.action_viewer": "Enable Action Viewer",
   "codeclient.config.action_viewer.description": "Pin code block description to the inventory while inside code chests.",
   "codeclient.config.invert_action_viewer_scroll": "Invert Scroll Direction",
   "codeclient.config.invert_action_viewer_scroll.description": "Invert the direction the action tooltip scrolls inside code chests.",
   "codeclient.config.action_viewer_alignment": "Tooltip Alignment",
   "codeclient.config.action_viewer_alignment.description": "Change where the tooltip displays inside code chests.",
-
 
   "codeclient.config.command.query": "Option %s is set to %s.",
   "codeclient.config.command.query.fail": "There is no option with name %s.",

--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -18,6 +18,8 @@
   "codeclient.config.insert_overlay.description": "Click on an empty slot in a code chest to insert a value.",
   "codeclient.config.param_ghosts": "Parameter Ghosts",
   "codeclient.config.param_ghosts.description": "See and be able to hover parameter information in chest slots.",
+  "codeclient.config.action_viewer": "Action Viewer",
+  "codeclient.config.action_viewer.description": "Pin code block description to the inventory while inside code chests.",
 
   "codeclient.config.command.query": "Option %s is set to %s.",
   "codeclient.config.command.query.fail": "There is no option with name %s.",

--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -20,7 +20,7 @@
   "codeclient.config.param_ghosts.description": "See and be able to hover parameter information in chest slots.",
 
   "codeclient.config.category.action_viewer": "Action Viewer",
-  "codeclient.config.category.action_viewer.description": "Display a tooltip displaying the code blocks description.",
+  "codeclient.config.category.action_viewer.description": "Display a tooltip that shows the code block's description.",
   "codeclient.config.action_viewer": "Enable Action Viewer",
   "codeclient.config.action_viewer.description": "Pin code block description to the inventory while inside code chests.",
   "codeclient.config.invert_action_viewer_scroll": "Invert Scroll Direction",

--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -18,8 +18,13 @@
   "codeclient.config.insert_overlay.description": "Click on an empty slot in a code chest to insert a value.",
   "codeclient.config.param_ghosts": "Parameter Ghosts",
   "codeclient.config.param_ghosts.description": "See and be able to hover parameter information in chest slots.",
-  "codeclient.config.action_viewer": "Action Viewer",
+  "codeclient.config.action_viewer": "Enable Action Viewer",
   "codeclient.config.action_viewer.description": "Pin code block description to the inventory while inside code chests.",
+  "codeclient.config.invert_action_viewer_scroll": "Invert Scroll Direction",
+  "codeclient.config.invert_action_viewer_scroll.description": "Invert the direction the action tooltip scrolls inside code chests.",
+  "codeclient.config.action_viewer_alignment": "Tooltip Alignment",
+  "codeclient.config.action_viewer_alignment.description": "Change where the tooltip displays inside code chests.",
+
 
   "codeclient.config.command.query": "Option %s is set to %s.",
   "codeclient.config.command.query.fail": "There is no option with name %s.",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,7 +14,8 @@
     "sources": "https://github.com/DFOnline/CodeClient"
   },
   "contributors": [
-    "RedVortex"
+    "RedVortex",
+    "msvae"
   ],
   "license": "MIT",
   "icon": "assets/codeclient/icon.png",


### PR DESCRIPTION
adds a tool tip overlay to code chest menus so you don't have to hover over the reference book to see descriptions. this overlay is toggle able through the config and is disabled by default.

## Examples
> ![example1](https://github.com/DFOnline/CodeClient/assets/66442608/d569e031-7a35-44f5-a0ca-9e4985d76e1d)
> example 1: a standard code block with minimal description.

> ![example2](https://github.com/DFOnline/CodeClient/assets/66442608/a674e7f0-f2bd-47b5-8cac-cd738609e201)
> example 2: a standard code block with a large description.

> ![example3](https://github.com/DFOnline/CodeClient/assets/66442608/efedcf8a-63c8-4ab9-b35b-503610c3aa63)
> example 3: example of normal tooltips displaying over the action's description.

> ![example4](https://github.com/DFOnline/CodeClient/assets/66442608/250cd3ca-b748-45d9-8156-1c8da4160f02)
> example 4: example of a call function block displaying it's description. (only works if reference book is in your inventory)
