### PR TITLE
Show Scope Under Variable Name

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/config/Config.java
+++ b/src/main/java/dev/dfonline/codeclient/config/Config.java
@@ -74,6 +74,7 @@ public class Config {
     public Boolean ValueDetails = true;
     public Boolean PhaseToggle = false;
     public static DestroyItemReset DestroyItemResetMode = DestroyItemReset.OFF;
+    public boolean ShowVariableScopeBelowName = true;
 
     public Config() {
     }
@@ -151,6 +152,7 @@ public class Config {
             object.addProperty("RecentValues", RecentValues);
             object.addProperty("PhaseToggle", PhaseToggle);
             object.addProperty("DestroyItemReset", DestroyItemResetMode.name());
+            object.addProperty("ShowVariableScopeBelowName", ShowVariableScopeBelowName);
             FileManager.writeConfig(object.toString());
         } catch (Exception e) {
             CodeClient.LOGGER.info("Couldn't save config: " + e);
@@ -577,6 +579,16 @@ public class Config {
                                 .controller(TickBoxControllerBuilder::create)
                                 .available(true)
                                 .flag(OptionFlag.RELOAD_CHUNKS)
+                                .build())
+                        .option(Option.createBuilder(Boolean.class)
+                                .name(Text.translatable("codeclient.config.show_variable_scope_below_name"))
+                                .description(OptionDescription.of(Text.translatable("codeclient.config.show_variable_scope_below_name.description")))
+                                .binding(
+                                        true,
+                                        () -> ShowVariableScopeBelowName,
+                                        opt -> ShowVariableScopeBelowName = opt
+                                )
+                                .controller(TickBoxControllerBuilder::create)
                                 .build())
                         .option(Option.createBuilder(Boolean.class)
                                 .name(Text.translatable("codeclient.config.show_i_on_line_scope"))

--- a/src/main/java/dev/dfonline/codeclient/mixin/render/hud/MInGameHud.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/render/hud/MInGameHud.java
@@ -1,8 +1,6 @@
 package dev.dfonline.codeclient.mixin.render.hud;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import dev.dfonline.codeclient.CodeClient;
 import dev.dfonline.codeclient.OverlayManager;
 import dev.dfonline.codeclient.config.Config;
@@ -77,9 +75,15 @@ public abstract class MInGameHud {
         if (!publicBukkit.contains("hypercube:varitem")) return;
         String varItem = publicBukkit.getString("hypercube:varitem");
 
-        JsonObject varItemJson = JsonParser.parseString(varItem).getAsJsonObject();
-
+        JsonObject varItemJson;
+        try {
+            varItemJson = JsonParser.parseString(varItem).getAsJsonObject();
+        } catch (JsonParseException ignored) {
+            // Invalid varitem json, do nothing.
+            return;
+        }
         String type = varItemJson.get("id").getAsString();
+
         JsonElement varName = varItemJson.getAsJsonObject("data").get("name");
         if (varName == null) return;
 
@@ -99,7 +103,7 @@ public abstract class MInGameHud {
                 int x2 = (scaledWidth - getTextRenderer().getWidth(scope.longName)) / 2;
                 int y2 = scaledHeight - 35;
                 context.drawTextWithShadow(getTextRenderer(), Text.literal(scope.longName).fillStyle(Style.EMPTY.withColor(scope.color)), x2, y2, 0xffffff);
-            } catch (IllegalArgumentException ignored) {
+            } catch (IllegalArgumentException ignored2) {
                 // invalid scope, do nothing. (same behavior as scope on variable item)
             }
         }

--- a/src/main/java/dev/dfonline/codeclient/mixin/render/hud/MInGameHud.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/render/hud/MInGameHud.java
@@ -1,13 +1,20 @@
 package dev.dfonline.codeclient.mixin.render.hud;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import dev.dfonline.codeclient.CodeClient;
 import dev.dfonline.codeclient.OverlayManager;
 import dev.dfonline.codeclient.config.Config;
 import dev.dfonline.codeclient.dev.overlay.ChestPeeker;
 import dev.dfonline.codeclient.dev.overlay.SignPeeker;
+import dev.dfonline.codeclient.hypercube.item.Scope;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -53,6 +60,48 @@ public abstract class MInGameHud {
         } catch (Exception ignored) {
             context.drawTooltip(textRenderer, Text.literal("An error occurred"), x, yOrig);
 
+        }
+    }
+
+    @Shadow
+    private ItemStack currentStack;
+
+    @Inject(method = "renderHeldItemTooltip", at = @At(value = "HEAD"), cancellable = true)
+    public void renderHeldItemTooltip(DrawContext context, CallbackInfo ci) {
+
+        if (!currentStack.hasNbt()) return;
+        NbtCompound nbt = currentStack.getNbt();
+        if (nbt == null) return;
+        if (!nbt.contains("PublicBukkitValues")) return;
+        NbtCompound publicBukkit = nbt.getCompound("PublicBukkitValues");
+        if (!publicBukkit.contains("hypercube:varitem")) return;
+        String varItem = publicBukkit.getString("hypercube:varitem");
+
+        JsonObject varItemJson = JsonParser.parseString(varItem).getAsJsonObject();
+
+        String type = varItemJson.get("id").getAsString();
+        JsonElement varName = varItemJson.getAsJsonObject("data").get("name");
+        if (varName == null) return;
+
+        if (type.equals("var")) {
+            ci.cancel();
+
+            // Render variable name.
+            Text nameText = Text.literal(varName.getAsString());
+            int x1 = (scaledWidth - getTextRenderer().getWidth(nameText)) / 2;
+            int y1 = scaledHeight - 45;
+            context.drawTextWithShadow(getTextRenderer(), nameText, x1, y1, 0xffffff);
+
+            // Render variable scope, if this throws an exception it can only
+            // mean Scope.valueOf() failed, as such the scope is invalid.
+            try {
+                Scope scope = Scope.valueOf(varItemJson.getAsJsonObject("data").get("scope").getAsString());
+                int x2 = (scaledWidth - getTextRenderer().getWidth(scope.longName)) / 2;
+                int y2 = scaledHeight - 35;
+                context.drawTextWithShadow(getTextRenderer(), Text.literal(scope.longName).fillStyle(Style.EMPTY.withColor(scope.color)), x2, y2, 0xffffff);
+            } catch (IllegalArgumentException ignored) {
+                // invalid scope, do nothing. (same behavior as scope on variable item)
+            }
         }
     }
 }

--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -104,6 +104,8 @@
   "codeclient.config.show_invisible_blocks": "Show Invisible Blocks",
   "codeclient.config.show_invisible_blocks.description1": "Show blocks like barriers and other invisible blocks whilst building or coding.",
   "codeclient.config.show_invisible_blocks.description2": "Laggy as of now",
+  "codeclient.config.show_variable_scope_below_name": "Show Variable Scope Below Name",
+  "codeclient.config.show_variable_scope_below_name.description": "Show the scope of a variable below its name when held, additionally stops the variable name from disappearing.",
   "codeclient.config.show_i_on_line_scope": "Show I On Line Scope",
   "codeclient.config.show_i_on_line_scope.description": "Whenever LINE is shortened, shorten it to I instead of L to avoid confusion with the LOCAL scope.",
   "codeclient.config.show_sign_text_from_behind": "Show sign text from behind",


### PR DESCRIPTION
Shows a variable's scope under its name, without fading out like normal item name tooltips