### PR TITLE
fix: item tags showing up on action viewer

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/hypercube/ReferenceBook.java
+++ b/src/main/java/dev/dfonline/codeclient/hypercube/ReferenceBook.java
@@ -31,8 +31,19 @@ public class ReferenceBook {
         return book;
     }
 
+    /**
+     * This function exists to fix a compatibility issue with previewing items tags.
+     * (e.g. the {@link dev.dfonline.codeclient.dev.overlay.ActionViewer}'s fallback tooltip)
+     * @return the reference book without any tags applied to it.
+     */
+    public ItemStack getTaglessItem() {
+        var tagless = book.copy();
+        tagless.setSubNbt("PublicBukkitValues", null);
+        return tagless;
+    }
+
     public List<Text> getTooltip() {
-        return book.getTooltip(null, TooltipContext.BASIC);
+        return getTaglessItem().getTooltip(null, TooltipContext.BASIC);
     }
 
     // todo: parse into action?


### PR DESCRIPTION
fixes the issue where holding down the item tag preview would cause the action viewer to also display item tags. this previously would only happen when using the "fallback" of the reference book item to fill the action viewer.