### PR TITLE
fix: add a missing comma into language file

### DIFF
--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -119,7 +119,7 @@
   "codeclient.config.cpu_display": "On-Screen CPU Display",
   "codeclient.config.cpu_display.description": "Whether to show the plot's CPU usage onscreen separate from the actionbar.",
   "codeclient.config.cpu_display_corner.name": "On-Screen CPU Display Corner",
-  "codeclient.config.cpu_display_corner.description": "Which corner to place the on-screen CPU display."
+  "codeclient.config.cpu_display_corner.description": "Which corner to place the on-screen CPU display.",
   "codeclient.config.action_viewer": "Action Viewer",
   "codeclient.config.action_viewer.description": "Display a tooltip that shows the code block's description.",
   "codeclient.config.action_viewer.enable": "Enable Action Viewer",


### PR DESCRIPTION
missing comma broke all translation strings (blame red :P)