### PR TITLE
expression higlighter fixes

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/dev/highlighter/ExpressionHighlighter.java
+++ b/src/main/java/dev/dfonline/codeclient/dev/highlighter/ExpressionHighlighter.java
@@ -114,6 +114,7 @@ public class ExpressionHighlighter extends Feature {
                     if (Config.getConfig().HighlightExpressions) text = highlightExpressions(text);
                 }
                 default -> {
+                    cachedHighlight = null;
                     return null;
                 }
             }

--- a/src/main/java/dev/dfonline/codeclient/dev/highlighter/ExpressionHighlighter.java
+++ b/src/main/java/dev/dfonline/codeclient/dev/highlighter/ExpressionHighlighter.java
@@ -102,14 +102,18 @@ public class ExpressionHighlighter extends Feature {
             VarItem varItem = VarItems.parse(item);
             Component text;
 
+            boolean showPreview = false;
+
             switch (varItem.getId()) {
                 case "num", "var", "txt" -> {
-                        if (Config.getConfig().HighlightExpressions) text = highlightExpressions(input);
+                        if (Config.getConfig().HighlightExpressions) text = highlightExpressions(input, true);
                         else text = Component.text(input);
                 }
                 case "comp" -> {
                     if (Config.getConfig().HighlightMiniMessage) text = highlighter.highlight(input);
                     else text = Component.text(input);
+
+                    showPreview = true;
 
                     if (Config.getConfig().HighlightExpressions) text = highlightExpressions(text);
                 }
@@ -119,7 +123,8 @@ public class ExpressionHighlighter extends Feature {
                 }
             }
 
-            Component preview = formatter.deserialize(input);
+            Component preview = Component.empty();
+            if (showPreview) preview = formatter.deserialize(input);
 
             cachedHighlight = new HighlightedExpression(subSequence(componentToOrderedText(text), range), componentToOrderedText(preview));
             return cachedHighlight;
@@ -161,7 +166,7 @@ public class ExpressionHighlighter extends Feature {
 
             if (Config.getConfig().HighlightExpressions) highlighted = highlightExpressions(highlighted);
         } else {
-            if (Config.getConfig().HighlightExpressions) highlighted = highlightExpressions(input.substring(start,end));
+            if (Config.getConfig().HighlightExpressions) highlighted = highlightExpressions(input.substring(start,end), true);
             else highlighted = Component.text(input.substring(start,end));
         }
 
@@ -184,10 +189,12 @@ public class ExpressionHighlighter extends Feature {
     private Component highlightExpressions(Component component) {
         String raw = formatter.serialize(component);
 
-        return highlightExpressions(raw);
+        return highlightExpressions(raw, false);
     }
 
-    private Component highlightExpressions(String raw) {
+    private Component highlightExpressions(String input, boolean escapeTags) {
+        String raw = escapeTags ? formatter.escapeTags(input) : input;
+
         StringBuilder sb = new StringBuilder(raw.length());
 
         Pattern pattern = Pattern.compile("(%[a-zA-Z]+\\(?)|\\)|$");

--- a/src/main/java/dev/dfonline/codeclient/mixin/screen/chat/MChatInputSuggester.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/screen/chat/MChatInputSuggester.java
@@ -3,6 +3,7 @@ package dev.dfonline.codeclient.mixin.screen.chat;
 import dev.dfonline.codeclient.CodeClient;
 import dev.dfonline.codeclient.dev.highlighter.ExpressionHighlighter;
 import dev.dfonline.codeclient.location.Dev;
+import net.kyori.adventure.text.Component;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ChatInputSuggestor;
 import net.minecraft.client.gui.widget.TextFieldWidget;
@@ -39,7 +40,9 @@ public class MChatInputSuggester {
 
             if (expression == null) return;
 
-            preview = expression.preview();
+            if (preview != OrderedText.empty()) preview = expression.preview();
+            else preview = null;
+
             cir.setReturnValue(expression.text());
         });
     }


### PR DESCRIPTION
- fixes an issue where holding a var item that doesnt take formatting would cause your last inputted value to overwrite the input box.
- fixes an issue where strings, numbers, and variables would show a preview above that chat bar even though they contain no minimessage formatting.
- fixes an issue where minimessage tags would still parse inside of the input box on strings, numbers, and variables when they are not supposed to.