### PR TITLE
Fixed CPU Usage not showing up in Top Left

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/mixin/render/hud/MInGameHud.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/render/hud/MInGameHud.java
@@ -53,7 +53,7 @@ public abstract class MInGameHud {
                 index++;
             }
         }
-        if (cpuUsage != null && Config.getConfig().CPUDisplayCornerOption != Config.CPUDisplayCorner.TOP_LEFT) {
+        if (cpuUsage != null) {
             int margin = 30;
             int x = switch (Config.getConfig().CPUDisplayCornerOption) {
                 case TOP_LEFT, BOTTOM_LEFT -> margin;


### PR DESCRIPTION
I think this fixes the CPU Usage not showing up in the top left even when you have TOP_LEFT selected in config