### PR TITLE
feat: config-related changes

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/command/impl/CommandCCConfig.java
+++ b/src/main/java/dev/dfonline/codeclient/command/impl/CommandCCConfig.java
@@ -81,13 +81,24 @@ public class CommandCCConfig extends Command {
                     for (Object member : field.getType().getEnumConstants()) {
                         if (((Enum<?>) member).name().equalsIgnoreCase(value)) {
                             field.set(Config.getConfig(), member);
-                            Utility.sendMessage(Text.translatable("codeclient.config.command.enum", Text.literal(option).formatted(Formatting.AQUA), Text.literal(value).formatted(Formatting.AQUA)), ChatType.SUCCESS);
+                            Utility.sendMessage(Text.translatable("codeclient.config.command.set", Text.literal(option).formatted(Formatting.AQUA), Text.literal(value).formatted(Formatting.AQUA)), ChatType.SUCCESS);
                             Config.getConfig().save();
                             return 0;
                         }
                     }
-                    Utility.sendMessage(Text.translatable("codeclient.config.command.enum.fail", Text.literal(option).formatted(Formatting.YELLOW), Text.literal(value).formatted(Formatting.YELLOW)), ChatType.FAIL);
+                    Utility.sendMessage(Text.translatable("codeclient.config.command.set.fail", Text.literal(option).formatted(Formatting.YELLOW), Text.literal(value).formatted(Formatting.YELLOW)), ChatType.FAIL);
                     return -1;
+                } else if (field.getType().equals(int.class)) {
+                    try {
+                        var number = Integer.parseInt(value);
+                        field.set(Config.getConfig(), number);
+                        Utility.sendMessage(Text.translatable("codeclient.config.command.set", Text.literal(option).formatted(Formatting.AQUA), Text.literal(String.valueOf(number)).formatted(Formatting.AQUA)), ChatType.SUCCESS);
+                        Config.getConfig().save();
+                        return 0;
+                    } catch (NumberFormatException e) {
+                        Utility.sendMessage(Text.translatable("codeclient.config.command.set.fail", Text.literal(option).formatted(Formatting.YELLOW), Text.literal(value).formatted(Formatting.YELLOW)), ChatType.FAIL);
+                        return -1;
+                    }
                 }
                 Utility.sendMessage(Text.translatable("codeclient.config.command.fail"), ChatType.FAIL);
             } catch (Exception ignored) {

--- a/src/main/java/dev/dfonline/codeclient/config/Config.java
+++ b/src/main/java/dev/dfonline/codeclient/config/Config.java
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 
 public class Config {
     private static Config instance;
-    public boolean NoClipEnabled = true;
+    public boolean NoClipEnabled = false;
     public boolean PlaceOnAir = false;
     public int AirSpeed = 10;
     public boolean CodeClientAPI = false;
@@ -37,7 +37,6 @@ public class Config {
     public float ReachDistance = 5;
     public boolean AutoFly = false;
     public LayerInteractionMode CodeLayerInteractionMode = LayerInteractionMode.AUTO;
-    public boolean AirControl = false;
     public boolean FocusSearch = false;
     public CharSetOption SaveCharSet = CharSetOption.UTF_8;
     public boolean RecentChestInsert = true;
@@ -78,7 +77,7 @@ public class Config {
     public boolean DevNodes = false;
     public boolean GiveUuidNameStrings = true;
     public boolean CPUDisplay = true;
-    public CPUDisplayCorner CPUDisplayCornerOption = CPUDisplayCorner.TOP_LEFT;
+    public CPUDisplayCornerOption CPUDisplayCorner = CPUDisplayCornerOption.TOP_LEFT;
     public boolean HideScopeChangeMessages = true;
     public boolean HighlighterEnabled = true;
     public boolean HighlightExpressions = true;
@@ -125,7 +124,6 @@ public class Config {
             object.addProperty("ReachDistance", ReachDistance);
             object.addProperty("AutoFly", AutoFly);
             object.addProperty("CodeLayerInteractionMode", CodeLayerInteractionMode.name());
-            object.addProperty("AirControl", AirControl);
             object.addProperty("FocusSearch", FocusSearch);
             object.addProperty("SaveCharSet", SaveCharSet.name());
             object.addProperty("RecentChestInsert", RecentChestInsert);
@@ -165,7 +163,7 @@ public class Config {
             object.addProperty("DevNodes", DevNodes);
             object.addProperty("GiveUuidNameStrings", GiveUuidNameStrings);
             object.addProperty("CPUDisplay", CPUDisplay);
-            object.addProperty("CPUDisplayCorner", CPUDisplayCornerOption.name());
+            object.addProperty("CPUDisplayCorner", CPUDisplayCorner.name());
             object.addProperty("HideScopeChangeMessages", HideScopeChangeMessages);
 
             object.addProperty("HighlighterEnabled", HighlighterEnabled);
@@ -337,7 +335,7 @@ public class Config {
                                         .text(Text.translatable("codeclient.config.noclip.description"))
                                         .build())
                                 .binding(
-                                        true,
+                                        false,
                                         () -> NoClipEnabled,
                                         opt -> NoClipEnabled = opt
                                 )
@@ -360,7 +358,7 @@ public class Config {
                                 .build())
                         .option(Option.createBuilder(float.class)
                                 .name(Text.translatable("codeclient.config.angle_up"))
-                                .description(OptionDescription.of(Text.translatable("codeclient.config.angle_up.description")))
+                                .description(OptionDescription.of(Text.translatable("codeclient.config.angle_up.description"), Text.translatable("codeclient.config.requires_noclip")))
                                 .binding(
                                         50F,
                                         () -> UpAngle,
@@ -370,7 +368,7 @@ public class Config {
                                 .build())
                         .option(Option.createBuilder(float.class)
                                 .name(Text.translatable("codeclient.config.angle_down"))
-                                .description(OptionDescription.of(Text.translatable("codeclient.config.angle_down.description")))
+                                .description(OptionDescription.of(Text.translatable("codeclient.config.angle_down.description"), Text.translatable("codeclient.config.requires_noclip")))
                                 .binding(50F,
                                         () -> DownAngle,
                                         opt -> DownAngle = opt
@@ -379,7 +377,7 @@ public class Config {
                                 .build())
                         .option(Option.createBuilder(boolean.class)
                                 .name(Text.translatable("codeclient.config.tp_up"))
-                                .description(OptionDescription.of(Text.translatable("codeclient.config.tp_up.description")))
+                                .description(OptionDescription.of(Text.translatable("codeclient.config.tp_up.description"), Text.translatable("codeclient.config.requires_noclip")))
                                 .binding(
                                         false,
                                         () -> TeleportUp,
@@ -389,7 +387,7 @@ public class Config {
                                 .build())
                         .option(Option.createBuilder(boolean.class)
                                 .name(Text.translatable("codeclient.config.tp_down"))
-                                .description(OptionDescription.of(Text.translatable("codeclient.config.tp_down.description")))
+                                .description(OptionDescription.of(Text.translatable("codeclient.config.tp_down.description"), Text.translatable("codeclient.config.requires_noclip")))
                                 .binding(
                                         false,
                                         () -> TeleportDown,
@@ -409,18 +407,6 @@ public class Config {
                                 )
                                 .controller(TickBoxControllerBuilder::create)
                                 .build())
-//                                .option(Option.createBuilder(boolean.class)
-//                                        .name(Text.literal("Air Control"))
-//                                        .description(OptionDescription.createBuilder()
-//                                                .text(Text.literal("Gives you the same control in air as walking."))
-//                                                .build())
-//                                        .binding(
-//                                                false,
-//                                                () -> AirControl,
-//                                                opt -> AirControl = opt
-//                                        )
-//                                        .controller(TickBoxController::new)
-//                                        .build())
                         .build())
                 //</editor-fold>
                 //<editor-fold desc="Interaction">
@@ -672,15 +658,15 @@ public class Config {
                                 )
                                 .controller(TickBoxControllerBuilder::create)
                                 .build())
-                        .option(Option.createBuilder(Config.CPUDisplayCorner.class)
+                        .option(Option.createBuilder(CPUDisplayCornerOption.class)
                                 .name(Text.translatable("codeclient.config.cpu_display_corner.name"))
                                 .description(OptionDescription.of(Text.translatable("codeclient.config.cpu_display_corner.description")))
                                 .binding(
-                                        CPUDisplayCorner.TOP_LEFT,
-                                        () -> CPUDisplayCornerOption,
-                                        opt -> CPUDisplayCornerOption = opt
+                                        CPUDisplayCornerOption.TOP_LEFT,
+                                        () -> CPUDisplayCorner,
+                                        opt -> CPUDisplayCorner = opt
                                 )
-                                .controller(nodeOption -> () -> new EnumController<>(nodeOption, Config.CPUDisplayCorner.class))
+                                .controller(nodeOption -> () -> new EnumController<>(nodeOption, CPUDisplayCornerOption.class))
                                 .build())
                         .option(Option.createBuilder(Boolean.class)
                                 .name(Text.translatable("codeclient.config.hide_scope_change_messages"))
@@ -1017,7 +1003,7 @@ public class Config {
         }
     }
 
-    public enum CPUDisplayCorner {
+    public enum CPUDisplayCornerOption {
         TOP_LEFT,
         TOP_RIGHT,
         BOTTOM_LEFT,

--- a/src/main/java/dev/dfonline/codeclient/dev/Navigation.java
+++ b/src/main/java/dev/dfonline/codeclient/dev/Navigation.java
@@ -32,6 +32,7 @@ public class Navigation extends Feature {
     public boolean onCrouch(boolean lastSneaking) {
         var player = CodeClient.MC.player;
         if (CodeClient.location instanceof Dev dev
+                && Config.getConfig().NoClipEnabled
                 && Config.getConfig().TeleportDown
                 && player != null
                 && dev.isInDevSpace()
@@ -53,6 +54,7 @@ public class Navigation extends Feature {
     public Float jumpHeight() {
         if (CodeClient.location instanceof Dev dev
                 && dev.isInDev(CodeClient.MC.player.getPos())
+                && Config.getConfig().NoClipEnabled
                 && CodeClient.MC.player.getPitch() <= Config.getConfig().UpAngle - 90)
             return 0.91f;
         return null;

--- a/src/main/java/dev/dfonline/codeclient/mixin/render/hud/MInGameHud.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/render/hud/MInGameHud.java
@@ -42,24 +42,28 @@ public abstract class MInGameHud {
 
         List<Text> overlay = new ArrayList<>(List.copyOf(OverlayManager.getOverlayText()));
         Text cpuUsage = OverlayManager.getCpuUsage();
-        if (!overlay.isEmpty()) {
-            if (cpuUsage != null && Config.getConfig().CPUDisplayCornerOption == Config.CPUDisplayCorner.TOP_LEFT) {
+        if (cpuUsage != null && Config.getConfig().CPUDisplayCorner == Config.CPUDisplayCornerOption.TOP_LEFT) {
+            if (overlay.isEmpty()) overlay.add(cpuUsage);
+            else {
                 overlay.add(0, cpuUsage);
                 overlay.add(1, Text.empty());
             }
+        }
+        if (!overlay.isEmpty()) {
             int index = 0;
             for (Text text : overlay) {
                 context.drawTextWithShadow(textRenderer, Objects.requireNonNullElseGet(text, () -> Text.literal("NULL")), 30, 30 + (index * 9), -1);
                 index++;
             }
         }
-        if (cpuUsage != null && Config.getConfig().CPUDisplayCornerOption != Config.CPUDisplayCorner.TOP_LEFT) {
+
+        if (cpuUsage != null && Config.getConfig().CPUDisplayCorner != Config.CPUDisplayCornerOption.TOP_LEFT) {
             int margin = 30;
-            int x = switch (Config.getConfig().CPUDisplayCornerOption) {
+            int x = switch (Config.getConfig().CPUDisplayCorner) {
                 case TOP_LEFT, BOTTOM_LEFT -> margin;
                 case TOP_RIGHT, BOTTOM_RIGHT -> scaledWidth - margin - textRenderer.getWidth(cpuUsage);
             };
-            int y = switch (Config.getConfig().CPUDisplayCornerOption) {
+            int y = switch (Config.getConfig().CPUDisplayCorner) {
                 case TOP_LEFT, TOP_RIGHT -> margin;
                 case BOTTOM_LEFT, BOTTOM_RIGHT -> scaledHeight - margin - 3;
             };

--- a/src/main/resources/assets/codeclient/lang/en_us.json
+++ b/src/main/resources/assets/codeclient/lang/en_us.json
@@ -19,6 +19,7 @@
   "codeclient.config": "CodeClient Config",
 
   "codeclient.config.requires_restart": "(requires restart)",
+  "codeclient.config.requires_noclip": "(requires NoClip)",
   "codeclient.config.default_recommended": "Default recommended.",
 
   "codeclient.config.tab.general": "General",
@@ -57,7 +58,7 @@
   "codeclient.config.tab.navigation.description": "How you move about in the codespace and the likes.",
 
   "codeclient.config.noclip": "NoClip",
-  "codeclient.config.noclip.description": "If you can NoClip in the dev space.",
+  "codeclient.config.noclip.description": "Whether you can walk through codeblocks, additionally enables codespace travel by looking up/down and jumping/sneaking.",
   "codeclient.config.airstrafe_modifier": "AirStrafe Modifier",
   "codeclient.config.airstrafe_modifier.description1": "How much faster you go when jumping in dev space.",
   "codeclient.config.airstrafe_modifier.description2": "Your jump speed will be based of walking speed.",
@@ -190,8 +191,8 @@
   "codeclient.config.command.query.fail": "There is no option with name %s.",
   "codeclient.config.command.enable": "Enabled option %s.",
   "codeclient.config.command.disable": "Disabled option %s.",
-  "codeclient.config.command.enum": "Set option %s to %s.",
-  "codeclient.config.command.enum.fail": "Couldn't set option %s to %s.",
+  "codeclient.config.command.set": "Set option %s to %s.",
+  "codeclient.config.command.set.fail": "Couldn't set option %s to %s.",
   "codeclient.config.command.fail": "You cannot set this config option.",
 
   "codeclient.config.destroy_item_reset.name": "Destroy Item Reset",


### PR DESCRIPTION
- NoClip off by default
- Fixed looking up and jumping making you jump higher when NoClip is off
- Add (requires NoClip) to movement settings that only work when NoClip is on
- Remove unused AirControl config option, which does not appear in the menu but still saves
- Allow /ccconfig to change integers
- Fix CPU display not loading from config file
- Fix CPU display does not render on the top left unless a CCDBUG overlay is active