### PR TITLE
Removed luke.cash from unofficialDFAddresses

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/mixin/screen/MMultiplayerScreen.java
+++ b/src/main/java/dev/dfonline/codeclient/mixin/screen/MMultiplayerScreen.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 @Mixin(MultiplayerScreen.class)
 public abstract class MMultiplayerScreen {
     @Unique
-    private static final String[] unofficialDFAddresses = {"mcdiamondfire.net", "luke.cash", "reason.codes", "boobs.im"};
+    private static final String[] unofficialDFAddresses = {"mcdiamondfire.net", "reason.codes", "boobs.im"};
 
     @Shadow
     private ServerList serverList;


### PR DESCRIPTION
It is common knowledge that unsactioned web addresses have the potential to be used maliciously to redirect traffic to track individuals using the address. Thankfully, luke.cash does NOT do this and will NOT do this. 

As such, I have removed it from the unofficalDFAddress list.