### PR TITLE
fix: use 0.0.0.0 instead of localhost for WS bind address

### DIFF
--- a/src/main/java/dev/dfonline/codeclient/websocket/SocketHandler.java
+++ b/src/main/java/dev/dfonline/codeclient/websocket/SocketHandler.java
@@ -46,7 +46,7 @@ public class SocketHandler {
 
     public void start() {
         try {
-            websocket = new SocketServer(new InetSocketAddress("localhost", PORT), this);
+            websocket = new SocketServer(new InetSocketAddress("0.0.0.0", PORT), this);
             Thread socketThread = new Thread(websocket, "CodeClient-API");
             socketThread.start();
             CodeClient.LOGGER.info("Socket opened");


### PR DESCRIPTION
This makes it so that other machines on the same local network are able to use CodeClient API running on the host machine